### PR TITLE
Add generic pre-config capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Base level docker image containing all dependencies for DDF
   * Feature installation via `INSTALL_FEATURES=<feature1>;<feature2>;...`
   * Feature uninstallation via `UNINSTALL_FEATURES=<feature1>;<feature2>;...`
   * Startup apps via `STARTUP_APPS=<app1>;<app2>;...`
+  * Supports initial configuration via `$ENTRYPOINT_HOME/pre_config`
+    * All files and directories contained under the `$ENTRYPOINT_HOME/pre_config` directory will be copied under `$APP_HOME` _after_ all the other configuration steps have been performed
 
 
 ## Requirements
@@ -34,7 +36,7 @@ Any upstream containers must provide environment variables for:
 
 ## Usage
 
-This image is meant to be the basis for any ddf based image.
+This image is meant to be the basis for any ddf based image and cannot be run on its own.
 It packages the dependencies and an entrypoint script for use with any ddf based application
 
 ```Dockerfile

--- a/alpine/entrypoint/pre_start.sh
+++ b/alpine/entrypoint/pre_start.sh
@@ -45,6 +45,12 @@ if [ -n "$LDAP_HOST" ]; then
   fi
 fi
 
+# Copy any existing configuration files before starting the container
+if [ -d "$ENTRYPOINT_HOME/pre_config" ]; then
+  echo "Copying configuration files from $ENTRYPOINT_HOME/pre_config to $APP_HOME"
+  cp -r $ENTRYPOINT_HOME/pre_config/* $APP_HOME
+fi
+
 if [ -d "$ENTRYPOINT_HOME/pre" ]; then
   for f in "$ENTRYPOINT_HOME/pre/*";
     do


### PR DESCRIPTION
Added step to `pre_start.sh` script to copy all files in `$ENTRYPOINT/pre_config` under `$APP_HOME` and allow generic application pre-configuration.