### PR TITLE
Added support for profile:install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Base level docker image containing all dependencies for DDF
   * Startup apps via `STARTUP_APPS=<app1>;<app2>;...`
   * Supports initial configuration via `$ENTRYPOINT_HOME/pre_config`
     * All files and directories contained under the `$ENTRYPOINT_HOME/pre_config` directory will be copied under `$APP_HOME` _after_ all the other configuration steps have been performed
+  * Advance installation using install profiles via `INSTALL_PROFILE=<profile>`
+    * Place installation profiles under `$APP_HOME/etc/profiles/`
 
 
 ## Requirements

--- a/alpine/entrypoint/post_start.sh
+++ b/alpine/entrypoint/post_start.sh
@@ -6,7 +6,10 @@ do
 done
 
 $APP_HOME/bin/client waitForReady -r 12 -d 10
-$APP_HOME/bin/client admin:install /opt/ddfConfig.json -r 12 -d 10
+
+if [ -n "$INSTALL_PROFILE" ]; then
+  $APP_HOME/bin/client profile:install $INSTALL_PROFILE -r 12 -d 10
+fi
 
 if [ -n "$INSTALL_FEATURES" ]; then
   if [[ $INSTALL_FEATURES == *";"* ]]; then


### PR DESCRIPTION
Added an environment variable for `INSTALL_PROFILE=<profileName>` that will trigger the use of the `profile:install <profileName>` command