### PR TITLE
Added ability to modify the default SSL port

### DIFF
--- a/linux/entrypoint/post_start.sh
+++ b/linux/entrypoint/post_start.sh
@@ -5,10 +5,8 @@ do
    [[ "${LOGLINE}" == *"Binding bundle: [landing-page"* ]] && pkill -P $$ tail
 done
 
-# $APP_HOME/bin/client waitForReady -r 12 -d 10
-
-echo "Wait a minute for Karaf to start completely..."
-sleep 60
+#$APP_HOME/bin/client waitForReady -r 12 -d 10
+$APP_HOME/bin/client "while { (bundle:list -t 0 | grep -i \"active.*DDF\s::\sadmin\s::\sUI\" | tac) isEmpty } { echo -n \". \"; sleep 1 }; while {(\"3\" equals ((bundle:list -t 0 | grep -i -v \"active\" | grep -i \"hosts:\" | wc -l | tac) trim) | tac) equals \"false\"} { echo -n \". \"; sleep 1 }; echo \"\"; echo \"System Ready\""
 
 if [ -n "$INSTALL_PROFILE" ]; then
   $APP_HOME/bin/client profile:install $INSTALL_PROFILE -r 12 -d 10

--- a/linux/entrypoint/post_start.sh
+++ b/linux/entrypoint/post_start.sh
@@ -5,7 +5,10 @@ do
    [[ "${LOGLINE}" == *"Binding bundle: [landing-page"* ]] && pkill -P $$ tail
 done
 
-$APP_HOME/bin/client waitForReady -r 12 -d 10
+# $APP_HOME/bin/client waitForReady -r 12 -d 10
+
+echo "Wait a minute for Karaf to start completely..."
+sleep 60
 
 if [ -n "$INSTALL_PROFILE" ]; then
   $APP_HOME/bin/client profile:install $INSTALL_PROFILE -r 12 -d 10

--- a/linux/entrypoint/pre_start.sh
+++ b/linux/entrypoint/pre_start.sh
@@ -12,6 +12,7 @@ $ENTRYPOINT_HOME/certs.sh
 
 props set org.codice.ddf.system.hostname $_app_hostname $APP_HOME/etc/system.properties
 props set org.codice.ddf.system.siteName $_app_hostname $APP_HOME/etc/system.properties
+props set org.codice.ddf.system.httpsPort $APP_HTTPSPORT $APP_HOME/etc/system.properties
 props del localhost $APP_HOME/etc/users.properties
 props set $_app_hostname $_app_hostname,group,admin,manager,viewer,system-admin,system-history,systembundles $APP_HOME/etc/users.properties
 sed -i "s/localhost/$_app_hostname/" $APP_HOME/etc/users.attributes

--- a/linux/entrypoint/pre_start.sh
+++ b/linux/entrypoint/pre_start.sh
@@ -12,7 +12,6 @@ $ENTRYPOINT_HOME/certs.sh
 
 props set org.codice.ddf.system.hostname $_app_hostname $APP_HOME/etc/system.properties
 props set org.codice.ddf.system.siteName $_app_hostname $APP_HOME/etc/system.properties
-props set org.codice.ddf.system.httpsPort $HTTPS_PORT $APP_HOME/etc/system.properties
 props del localhost $APP_HOME/etc/users.properties
 props set $_app_hostname $_app_hostname,group,admin,manager,viewer,system-admin,system-history,systembundles $APP_HOME/etc/users.properties
 sed -i "s/localhost/$_app_hostname/" $APP_HOME/etc/users.attributes

--- a/linux/entrypoint/pre_start.sh
+++ b/linux/entrypoint/pre_start.sh
@@ -12,7 +12,7 @@ $ENTRYPOINT_HOME/certs.sh
 
 props set org.codice.ddf.system.hostname $_app_hostname $APP_HOME/etc/system.properties
 props set org.codice.ddf.system.siteName $_app_hostname $APP_HOME/etc/system.properties
-props set org.codice.ddf.system.httpsPort $APP_HTTPSPORT $APP_HOME/etc/system.properties
+props set org.codice.ddf.system.httpsPort $HTTPS_PORT $APP_HOME/etc/system.properties
 props del localhost $APP_HOME/etc/users.properties
 props set $_app_hostname $_app_hostname,group,admin,manager,viewer,system-admin,system-history,systembundles $APP_HOME/etc/users.properties
 sed -i "s/localhost/$_app_hostname/" $APP_HOME/etc/users.attributes
@@ -44,6 +44,10 @@ if [ -n "$LDAP_HOST" ]; then
   else
     props set org.codice.ddf.ldap.port 1636 $APP_HOME/etc/system.properties
   fi
+fi
+
+if [ -n "$HTTPS_PORT" ]; then
+   props set org.codice.ddf.system.httpsPort $HTTPS_PORT $APP_HOME/etc/system.properties
 fi
 
 # Copy any existing configuration files before starting the container


### PR DESCRIPTION
Mainly for SSL Port (Since we are running inside the container as root, we are allow to run on Port 443 without any issue)

Extracted out waitForReady command into the post_install.sh script until we resolve the issue loading shell.init.script into the new Karaf version.

@oconnormi and @millerw8