### PR TITLE
Allow user to update the default 4G Java Max Size for their environment

### DIFF
--- a/linux/entrypoint/pre_start.sh
+++ b/linux/entrypoint/pre_start.sh
@@ -49,6 +49,11 @@ if [ -n "$HTTPS_PORT" ]; then
    props set org.codice.ddf.system.httpsPort $HTTPS_PORT $APP_HOME/etc/system.properties
 fi
 
+if [ -n "$JAVA_MAX_MEM" ]; then
+   sed -i "s/Xmx.* /Xmx${JAVA_MAX_MEM}g /g" $APP_HOME/bin/setenv
+   sed -i "s/Xmx.* /Xmx${JAVA_MAX_MEM}g /g" $APP_HOME/bin/setenv.bat
+fi
+
 # Copy any existing configuration files before starting the container
 if [ -d "$ENTRYPOINT_HOME/pre_config" ]; then
   echo "Copying configuration files from $ENTRYPOINT_HOME/pre_config to $APP_HOME"


### PR DESCRIPTION
Set JAVA_MAX_MEM to update the default setting.  If it is not supply, it will keep the default setting.  Don't have a window machine, need to verify that the change would work on Windows machine as well.  