### PR TITLE
Adding support for remote cfssl based CA

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,16 +17,31 @@ Base level docker image containing all dependencies for DDF
   * Supports External solr via `SOLR_URL=<external_solr_url>`
   * Supports Solr Cloud via `SOLR_ZK_HOSTS=<zookeeper_hosts_list>`
   * Supports external ldap via `LDAP_HOST=<hostname>`
-  * Supports Clustering via `APP_NODENAME=<node_name>`
-    * NodeName is used to identify the node within the cluster, useful for loadbalancing
+  * Supports Clustering via `APP_NODENAME=<node_name>` *DEPRECATED* use `CSR_SAN=<DNS|IP>:<value>,...` instead
   * Feature installation via `INSTALL_FEATURES=<feature1>;<feature2>;...`
   * Feature uninstallation via `UNINSTALL_FEATURES=<feature1>;<feature2>;...`
   * Startup apps via `STARTUP_APPS=<app1>;<app2>;...`
+  * Can request certs from a remote cfssl based CA via `CA_REMOTE_URL=https://<host>:<port>`
 
+### Customizing CSR
+
+Only applicable when using `CA_REMOTE_URL`
+
+| Variable                  | Description                                                      | Default                        |
+|:-------------------------:|:----------------------------------------------------------------:|:------------------------------:|
+| `CSR_KEY_ALGORITHM`       | Sets the key algorithm for the generated Certificate             | `rsa`                          |
+| `CSR_KEY_SIZE`            | Sets the key size for the generated Certificate                  | `2048`                         |
+| `CSR_SAN`                 | Sets the SAN value for the generated Certificate                 | `DNS:<hostname>,DNS:localhost` |
+| `CSR_COUNTRY`             | Sets the Country value for the generated Certificate             | `US`                           |
+| `CSR_LOCALITY`            | Sets the Locality value for the generated Certificate            | `Hursley`                      |
+| `CSR_ORGANIZATION`        | Sets the Organization value for the generated Certificate        | `DDF`                          |
+| `CSR_ORGANIZATIONAL_UNIT` | Sets the Organizational Unit value for the generated Certificate | `Dev`                          |
+| `CSR_STATE`               | Sets the State value for the generated Certificate               | `AZ`                           |
+| `CSR_PROFILE`             | Sets the type of certificate requested from the CA               | `server`                       |
 
 ## Requirements
 
-Any upstream containers must provide environment variables for:
+Any downstream containers must provide environment variables for:
 
 * APP_NAME - Name of application, used for branding by the entrypoint
 * APP_HOME - Home Directory for application installation (should have a bin directory as a child)

--- a/linux/alpine/Dockerfile
+++ b/linux/alpine/Dockerfile
@@ -5,11 +5,12 @@ ENV ENTRYPOINT_HOME=/opt/entrypoint
 
 RUN mkdir -p $ENTRYPOINT_HOME
 
-COPY entrypoint/* $ENTRYPOINT_HOME/
-
 RUN apk add --no-cache curl openssl \
     && curl -L https://github.com/oconnormi/props/releases/download/v0.2.0/props_linux_amd64 -o /usr/local/bin/props \
     && chmod 755 /usr/local/bin/props \
-    && apk del --no-cache curl
+    && curl -LsSk https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 -o /usr/local/bin/jq \
+    && chmod 755 /usr/local/bin/jq
+
+COPY entrypoint/* $ENTRYPOINT_HOME/
 
 ENTRYPOINT ["/bin/bash", "-c", "$ENTRYPOINT_HOME/entrypoint.sh"]

--- a/linux/centos/Dockerfile
+++ b/linux/centos/Dockerfile
@@ -18,7 +18,9 @@ RUN yum update -y \
 RUN curl -OL "http://download.oracle.com/otn-pub/java/jdk/$JDK_VERSION-$JDK_BUILD_VERSION/d54c1d3a095b4ff2b6607d096fa80163/jdk-$JDK_VERSION-linux-x64.rpm" -H 'Cookie: oraclelicense=accept-securebackup-cookie' \
     && yum install -y jdk-$JDK_VERSION-linux-x64.rpm \
     && yum clean all \
-    && rm -f jdk-$JDK_VERSION-linux-x64.rpm
+    && rm -f jdk-$JDK_VERSION-linux-x64.rpm \
+    && curl -LsSk https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 -o /usr/local/bin/jq \
+    && chmod 755 /usr/local/bin/jq
 
 # Stage Entrypoint scripts
 RUN mkdir -p $ENTRYPOINT_HOME

--- a/linux/entrypoint/certs.sh
+++ b/linux/entrypoint/certs.sh
@@ -1,34 +1,11 @@
 #!/bin/bash
 
 # Generate certs
-# Need to account for both APP_HOSTNAME (for regular operation) and APP_NODENAME (for clustered operation)
-if [ -n "$APP_HOSTNAME" ]; then
-  _app_hostname=$APP_HOSTNAME
-else
-  _app_hostname=$(hostname -f)
-fi
-
-_keystoreName=$APP_HOME/etc/keystores/serverKeystore.jks
-_storepass=changeit
-_keytoolOpts="-keystore $_keystoreName -storepass $_storepass -noprompt"
-_san=DNS:$_app_hostname,DNS:localhost,IP:127.0.0.1
-_keyAlias=$_app_hostname
-_subject="/C=US/ST=AZ/L=Hursley/O=DDF/OU=Dev/CN=$_app_hostname"
-_serial=$(cat /dev/urandom | tr -dc '0-9' | fold -w 16 | head -n 1)
-
-DUMMY_DELETE_OPTS="-delete -alias localhost $_keytoolOpts"
-
-if [ -n "$APP_NODENAME" ]; then
-  _san+=,DNS:$APP_NODENAME
-fi
+source $ENTRYPOINT_HOME/certs_env.sh
 
 # Check if already complete
 keytool -list -alias $_keyAlias $_keytoolOpts > /dev/null 2>&1
 if [ $? -ne 0 ] ; then
-
-  echo "External Hostname: ${_app_hostname}"
-  echo "Alternative Names: $_san"
-  echo "Updating ${APP_NAME} certificates"
 
   keytool -list -alias localhost $_keytoolOpts > /dev/null 2>&1
   if [ $? -eq 0 ] ; then
@@ -36,55 +13,9 @@ if [ $? -ne 0 ] ; then
     keytool $DUMMY_DELETE_OPTS
   fi
 
-  # Generate random serial
-  echo $_serial > $APP_HOME/etc/certs/demoCA/serial
-
-  # Generate key
-  openssl genrsa \
-    -out $APP_HOME/etc/certs/demoCA/private/$_keyAlias.key \
-    4096 > /dev/null 2>&1
-
-  # Generate CSR
-  export _san
-  openssl req \
-    -new \
-    -sha256 \
-    -subj $_subject \
-    -key $APP_HOME/etc/certs/demoCA/private/$_keyAlias.key \
-    -out $APP_HOME/etc/certs/demoCA/$_keyAlias.csr \
-    -config $ENTRYPOINT_HOME/ca/openssl-demo.cnf > /dev/null 2>&1
-
-  echo "unique_subject = no" > $APP_HOME/etc/certs/demoCA/index.txt.attr
-  # Sign request using DDF Demo CA
-
-  openssl ca \
-          -batch \
-          -config $ENTRYPOINT_HOME/ca/openssl-demo.cnf \
-          -passin pass:secret \
-          -in $APP_HOME/etc/certs/demoCA/$_keyAlias.csr \
-          -out $APP_HOME/etc/certs/demoCA/newcerts/$_keyAlias.cer > /dev/null 2>&1
-
-  cat $APP_HOME/etc/certs/demoCA/cacert.pem \
-      $APP_HOME/etc/certs/demoCA/newcerts/$_keyAlias.cer \
-      $APP_HOME/etc/certs/demoCA/private/$_keyAlias.key \
-      > $APP_HOME/etc/certs/demoCA/private/$_keyAlias.pem
-
-  openssl pkcs12 \
-          -export \
-          -out $APP_HOME/etc/certs/demoCA/private/$_keyAlias.p12 \
-          -in $APP_HOME/etc/certs/demoCA/private/$_keyAlias.pem \
-          -passin pass:$_storepass \
-          -passout pass:$_storepass > /dev/null 2>&1
-
-  # Import Cert
-  keytool -importkeystore \
-          $_keytoolOpts \
-          -keypass $_storepass \
-          -srcstorepass $_storepass \
-          -srckeystore $APP_HOME/etc/certs/demoCA/private/$_keyAlias.p12 > /dev/null 2>&1
-
-  keytool -changealias \
-          $_keytoolOpts \
-          -alias 1 \
-          -destalias $_keyAlias > /dev/null 2>&1
+  if [ -n "${_remote_ca}" ]; then
+    $ENTRYPOINT_HOME/remote_ca_request.sh
+  else
+    $ENTRYPOINT_HOME/local_ca_request.sh
+  fi
 fi

--- a/linux/entrypoint/certs_env.sh
+++ b/linux/entrypoint/certs_env.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+if [ -n "$APP_HOSTNAME" ]; then
+  _app_hostname=$APP_HOSTNAME
+else
+  _app_hostname=$(hostname -f)
+fi
+
+_remote_ca=${CA_REMOTE_URL:=""} # Set to host:port for remote CFSSL based CA
+_keystoreName=$APP_HOME/etc/keystores/serverKeystore.jks
+_trustStoreName=$APP_HOME/etc/keystores/serverTruststore.jks
+_storepass=changeit
+_trustStoreOpts="-keystore $_trustStoreName -storepass $_storepass -noprompt"
+_keytoolOpts="-keystore $_keystoreName -storepass $_storepass -noprompt"
+_san=DNS:$_app_hostname,DNS:localhost,IP:127.0.0.1
+_keyAlias=$_app_hostname
+
+DUMMY_DELETE_OPTS="-delete -alias localhost $_keytoolOpts"
+
+if [ -n "$APP_NODENAME" ]; then
+  echo "'APP_NODENAME' is deprecated, use 'CSR_SAN=<DNS|IP>:<value>,...' in the future"
+  _san+=,DNS:$APP_NODENAME
+fi
+
+if [ -n "$CSR_SAN" ]; then
+  _san+=$CSR_SAN
+fi

--- a/linux/entrypoint/local_ca_request.sh
+++ b/linux/entrypoint/local_ca_request.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+source $ENTRYPOINT_HOME/certs_env.sh
+
+_subject="/C=US/ST=AZ/L=Hursley/O=DDF/OU=Dev/CN=$_app_hostname"
+_serial=$(cat /dev/urandom | tr -dc '0-9' | fold -w 16 | head -n 1)
+
+echo "External Hostname: ${_app_hostname}"
+echo "Alternative Names: $_san"
+echo "Updating ${APP_NAME} certificates"
+
+# Generate random serial
+echo $_serial > $APP_HOME/etc/certs/demoCA/serial
+
+# Generate key
+openssl genrsa \
+  -out $APP_HOME/etc/certs/demoCA/private/$_keyAlias.key \
+  4096 > /dev/null 2>&1
+
+# Generate CSR
+export _san
+openssl req \
+  -new \
+  -sha256 \
+  -subj $_subject \
+  -key $APP_HOME/etc/certs/demoCA/private/$_keyAlias.key \
+  -out $APP_HOME/etc/certs/demoCA/$_keyAlias.csr \
+  -config $ENTRYPOINT_HOME/ca/openssl-demo.cnf > /dev/null 2>&1
+
+echo "unique_subject = no" > $APP_HOME/etc/certs/demoCA/index.txt.attr
+# Sign request using DDF Demo CA
+
+openssl ca \
+        -batch \
+        -config $ENTRYPOINT_HOME/ca/openssl-demo.cnf \
+        -passin pass:secret \
+        -in $APP_HOME/etc/certs/demoCA/$_keyAlias.csr \
+        -out $APP_HOME/etc/certs/demoCA/newcerts/$_keyAlias.cer > /dev/null 2>&1
+
+cat $APP_HOME/etc/certs/demoCA/cacert.pem \
+    $APP_HOME/etc/certs/demoCA/newcerts/$_keyAlias.cer \
+    $APP_HOME/etc/certs/demoCA/private/$_keyAlias.key \
+    > $APP_HOME/etc/certs/demoCA/private/$_keyAlias.pem
+
+openssl pkcs12 \
+        -export \
+        -out $APP_HOME/etc/certs/demoCA/private/$_keyAlias.p12 \
+        -in $APP_HOME/etc/certs/demoCA/private/$_keyAlias.pem \
+        -passin pass:$_storepass \
+        -passout pass:$_storepass > /dev/null 2>&1
+
+# Import Cert
+keytool -importkeystore \
+        $_keytoolOpts \
+        -keypass $_storepass \
+        -srcstorepass $_storepass \
+        -srckeystore $APP_HOME/etc/certs/demoCA/private/$_keyAlias.p12 > /dev/null 2>&1
+
+keytool -changealias \
+        $_keytoolOpts \
+        -alias 1 \
+        -destalias $_keyAlias > /dev/null 2>&1

--- a/linux/entrypoint/pre_start.sh
+++ b/linux/entrypoint/pre_start.sh
@@ -28,11 +28,6 @@ if [ -n "$SOLR_URL" ]; then
   props set solr.http.url $SOLR_URL $APP_HOME/etc/system.properties
 fi
 
-if [ -n "$APP_NODENAME" ]; then
-  echo "Cluster support enabled, Node Name: $APP_NODENAME"
-  props set org.codice.ddf.system.cluster.hostname $APP_NODENAME $APP_HOME/etc/system.properties
-fi
-
 # TODO: add more fine grained ldap configuration support
 if [ -n "$LDAP_HOST" ]; then
   echo "Remote LDAP HOST: $LDAP_HOST configured"

--- a/linux/entrypoint/remote_ca_request.sh
+++ b/linux/entrypoint/remote_ca_request.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+
+# Requests a certificate from a remote CFSSL based CA
+source $ENTRYPOINT_HOME/certs_env.sh
+
+_tmp_cert_dir=/tmp/ca_remote_request
+_tmp_output_dir=${_tmp_cert_dir}/out
+mkdir -p ${_tmp_output_dir}
+
+# function join_by { local IFS="$1"; shift; echo "$*"; }
+function join_by { local d=$1; shift; echo -n "$1"; shift; printf "%s" "${@/#/$d}"; }
+
+# prepare to sanitize san values for use with cfssl
+# cfssl does not require the DNS: and IP: prefixes
+_remote_request_key_alg=${CSR_KEY_ALGORITHM:="rsa"}
+_remote_request_key_size=${CSR_KEY_SIZE:="2048"}
+_remote_request_hosts=${_san}
+_remote_request_cn=${_app_hostname}
+_remote_request_names_country=${CSR_COUNTRY:="US"}
+_remote_request_names_locality=${CSR_LOCALITY:="Hursley"}
+_remote_request_names_organization=${CSR_ORGANIZATION:="DDF"}
+_remote_request_names_organizational_unit=${CSR_ORGANIZATIONAL_UNIT:="Dev"}
+_remote_request_names_state=${CSR_STATE:="AZ"}
+_remote_request_profile=${CSR_PROFILE:="server"}
+
+IFS=',' read -r -a _remote_request_hosts <<< "${_remote_request_hosts}"
+for index in "${!_remote_request_hosts[@]}"
+do
+  _remote_request_hosts[$index]=${_remote_request_hosts[$index]#DNS:}
+  _remote_request_hosts[$index]=${_remote_request_hosts[$index]#IP:}
+  _remote_request_hosts[$index]=\"${_remote_request_hosts[$index]}\"
+done
+
+_remote_request_hosts=$(join_by ' , ' ${_remote_request_hosts[@]})
+
+cat > ${_tmp_cert_dir}/csr.json << EOF
+{
+  "request": {
+    "CN": "${_remote_request_cn}",
+    "hosts": [ ${_remote_request_hosts} ],
+    "names": [{
+      "C": "${_remote_request_names_country}",
+      "L": "${_remote_request_names_locality}",
+      "O": "${_remote_request_names_organization}",
+      "OU": "${_remote_request_names_organizational_unit}",
+      "ST": "${_remote_request_names_state}"
+    }],
+    "key": {
+        "algo": "${_remote_request_key_alg}",
+        "size": ${_remote_request_key_size}
+    }
+  },
+  "profile": "${_remote_request_profile}",
+  "bundle": true
+}
+EOF
+
+echo "Generated CSR:"
+cat ${_tmp_cert_dir}/csr.json
+
+echo "Submitting CSR to ${_remote_ca}"
+curl -k -d @${_tmp_cert_dir}/csr.json \
+          ${_remote_ca}/api/v1/cfssl/newcert  \
+          | jq . > ${_tmp_cert_dir}/ca-response.json
+cat ${_tmp_cert_dir}/ca-response.json | jq .result.certificate --raw-output > ${_tmp_cert_dir}/$_keyAlias.pem
+cat ${_tmp_cert_dir}/ca-response.json | jq .result.private_key --raw-output > ${_tmp_cert_dir}/$_keyAlias.key
+openssl s_client -connect ${_remote_ca#https://} -showcerts </dev/null 2>/dev/null|openssl x509 -outform PEM > ${_tmp_cert_dir}/ca.pem
+
+cat ${_tmp_cert_dir}/ca.pem \
+    ${_tmp_cert_dir}/$_keyAlias.pem \
+    ${_tmp_cert_dir}/$_keyAlias.key \
+    > ${_tmp_output_dir}/$_keyAlias.pem
+
+openssl pkcs12 \
+        -export \
+        -out ${_tmp_output_dir}/$_keyAlias.p12 \
+        -in ${_tmp_output_dir}/$_keyAlias.pem \
+        -passin pass:$_storepass \
+        -passout pass:$_storepass > /dev/null 2>&1
+
+# Import Cert
+keytool -importkeystore \
+        $_keytoolOpts \
+        -keypass $_storepass \
+        -srcstorepass $_storepass \
+        -srckeystore ${_tmp_output_dir}/$_keyAlias.p12 > /dev/null 2>&1
+
+keytool -changealias \
+        $_keytoolOpts \
+        -alias 1 \
+        -destalias $_keyAlias > /dev/null 2>&1
+
+keytool -list -alias "ddf demo root ca" $_trustStoreOpts > /dev/null 2>&1
+if [ $? -eq 0 ] ; then
+  echo "'ddf demo root ca' key found in $_trustStoreName, removing"
+  keytool -delete -alias "ddf demo root ca" $_trustStoreOpts
+fi
+
+keytool -list -alias "ddf demo root ca" $_keytoolOpts > /dev/null 2>&1
+if [ $? -eq 0 ] ; then
+  echo "'ddf demo root ca' key found in $_keystoreName, removing"
+  keytool -delete -alias "ddf demo root ca" $_keytoolOpts
+fi
+
+keytool -importcert $_keytoolOpts -trustcacerts -alias rootCA -file ${_tmp_cert_dir}/ca.pem
+keytool -importcert $_trustStoreOpts -trustcacerts -alias rootCA -file ${_tmp_cert_dir}/ca.pem


### PR DESCRIPTION
This adds support for requesting certificates from a remote CFSSL CA server at startup
Remote CA can be specified via `REMOTE_CA_URL=https://<host>:<port>`. If not specified the default behavior is used instead and certificates will be generated from the local ddf demo ca on the filesystem