### PR TITLE
Install jdk 8u161 for centos

### DIFF
--- a/2.10/linux/centos/Dockerfile
+++ b/2.10/linux/centos/Dockerfile
@@ -3,19 +3,17 @@ MAINTAINER oconnormi
 
 # Environment Variables
 # JAVA Environment Variables
-ENV JDK_VERSION=8u131
-ENV JDK_BUILD_VERSION=b11
-ENV JAVA_HOME /usr/java/latest
-# DDF Environment Variables
-ENV ENTRYPOINT_HOME=/opt/entrypoint
+ENV JDK_VERSION=8u161 \
+    JDK_BUILD_VERSION=b12 \
+    JAVA_HOME=/usr/java/latest \
+    ENTRYPOINT_HOME=/opt/entrypoint
 
 # Update OS with necessary packages
 RUN yum update -y \
-    && yum install -y unzip \
-    && yum install -y openssl
+    && yum install -y unzip openssl
 
 # Download Oracle Java
-RUN curl -OL "http://download.oracle.com/otn-pub/java/jdk/$JDK_VERSION-$JDK_BUILD_VERSION/d54c1d3a095b4ff2b6607d096fa80163/jdk-$JDK_VERSION-linux-x64.rpm" -H 'Cookie: oraclelicense=accept-securebackup-cookie' \
+RUN curl -OL "http://download.oracle.com/otn-pub/java/jdk/$JDK_VERSION-$JDK_BUILD_VERSION/2f38c3b165be4555a1fa6e98c45e0808/jdk-$JDK_VERSION-linux-x64.rpm" -H 'Cookie: oraclelicense=accept-securebackup-cookie' \
     && yum install -y jdk-$JDK_VERSION-linux-x64.rpm \
     && yum clean all \
     && rm -f jdk-$JDK_VERSION-linux-x64.rpm \

--- a/2.11/linux/centos/Dockerfile
+++ b/2.11/linux/centos/Dockerfile
@@ -3,19 +3,17 @@ MAINTAINER oconnormi
 
 # Environment Variables
 # JAVA Environment Variables
-ENV JDK_VERSION=8u131
-ENV JDK_BUILD_VERSION=b11
-ENV JAVA_HOME /usr/java/latest
-# DDF Environment Variables
-ENV ENTRYPOINT_HOME=/opt/entrypoint
+ENV JDK_VERSION=8u161 \
+    JDK_BUILD_VERSION=b12 \
+    JAVA_HOME=/usr/java/latest \
+    ENTRYPOINT_HOME=/opt/entrypoint
 
 # Update OS with necessary packages
 RUN yum update -y \
-    && yum install -y unzip \
-    && yum install -y openssl
+    && yum install -y unzip openssl
 
 # Download Oracle Java
-RUN curl -OL "http://download.oracle.com/otn-pub/java/jdk/$JDK_VERSION-$JDK_BUILD_VERSION/d54c1d3a095b4ff2b6607d096fa80163/jdk-$JDK_VERSION-linux-x64.rpm" -H 'Cookie: oraclelicense=accept-securebackup-cookie' \
+RUN curl -OL "http://download.oracle.com/otn-pub/java/jdk/$JDK_VERSION-$JDK_BUILD_VERSION/2f38c3b165be4555a1fa6e98c45e0808/jdk-$JDK_VERSION-linux-x64.rpm" -H 'Cookie: oraclelicense=accept-securebackup-cookie' \
     && yum install -y jdk-$JDK_VERSION-linux-x64.rpm \
     && yum clean all \
     && rm -f jdk-$JDK_VERSION-linux-x64.rpm \

--- a/2.12/linux/centos/Dockerfile
+++ b/2.12/linux/centos/Dockerfile
@@ -3,19 +3,17 @@ MAINTAINER oconnormi
 
 # Environment Variables
 # JAVA Environment Variables
-ENV JDK_VERSION=8u131
-ENV JDK_BUILD_VERSION=b11
-ENV JAVA_HOME /usr/java/latest
-# DDF Environment Variables
-ENV ENTRYPOINT_HOME=/opt/entrypoint
+ENV JDK_VERSION=8u161 \
+    JDK_BUILD_VERSION=b12 \
+    JAVA_HOME=/usr/java/latest \
+    ENTRYPOINT_HOME=/opt/entrypoint
 
 # Update OS with necessary packages
 RUN yum update -y \
-    && yum install -y unzip \
-    && yum install -y openssl
+    && yum install -y unzip openssl
 
 # Download Oracle Java
-RUN curl -OL "http://download.oracle.com/otn-pub/java/jdk/$JDK_VERSION-$JDK_BUILD_VERSION/d54c1d3a095b4ff2b6607d096fa80163/jdk-$JDK_VERSION-linux-x64.rpm" -H 'Cookie: oraclelicense=accept-securebackup-cookie' \
+RUN curl -OL "http://download.oracle.com/otn-pub/java/jdk/$JDK_VERSION-$JDK_BUILD_VERSION/2f38c3b165be4555a1fa6e98c45e0808/jdk-$JDK_VERSION-linux-x64.rpm" -H 'Cookie: oraclelicense=accept-securebackup-cookie' \
     && yum install -y jdk-$JDK_VERSION-linux-x64.rpm \
     && yum clean all \
     && rm -f jdk-$JDK_VERSION-linux-x64.rpm \


### PR DESCRIPTION
Install latest jdk.  And also, believe the old oracle "agreement signature" doesn't work any more, so the old one probably can't download the old JDK at all.  