### PR TITLE
Add support for seeding catalog data from local and remote archives

### DIFF
--- a/2.12/linux/entrypoint/ingest_data.sh
+++ b/2.12/linux/entrypoint/ingest_data.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+
+source ${ENTRYPOINT_HOME}/global_env.sh
+
+# Two params
+# $1: URL to download
+# $2: staging location
+function retrieveRemoteData() {
+  _url=${1}
+  _dest=${2}
+  if curl -LsSk -o /dev/null -s -f -r 0-0 "${_url}"; then
+    echo -e "Retrieving remote metadata archive.\n\tFrom:\t\t${_url}\n\tStaging:\t${_dest}"
+    mkdir -p $(dirname ${_dest})
+    curl -LsSk ${_url} -o ${_dest}
+    return 0
+  else
+    echo "Unable to retrieve from: ${_url}"
+    return 1
+  fi
+}
+
+# Two params
+# $1: Path to copy from
+# $2: Path to copy to
+function copyLocalData() {
+  _path=${1#*//}
+  _dest=${2}
+  if [ ! -f ${_path} ]; then
+    echo "Local data archive: ${_path} does not exist!"
+    return 1
+  fi
+
+  echo -e "Copying local data archive.\n\tFrom:\t${_path}\n\tTo:\t${_dest}"
+  mkdir -p $(dirname ${_dest})
+  cp ${_path} ${_dest}
+  if [ ! -f ${_dest} ]; then
+    echo "Unable to stage archive to destination: ${_dest}"
+    return 1
+  fi
+}
+
+# Three params
+# $1: src path for archive
+# $2: dest path for extraction
+# $2: archive type
+function unpackData() {
+  _src=${1}
+  _dest=${2}
+  _type=${3}
+
+  if [ -n "${_type}" ]; then
+    _type=${_src#*.}
+  fi
+
+  echo -e "Extracting archive.\n\tType:\t${_type}\n\tSrc:\t${_src}\n\tDest:\t${_dest}"
+  case ${_type} in
+    "zip" )
+      unzip ${_src} -d ${_dest} && rm -rf ${_src}
+      return $?
+      ;;
+    "tar.gz" )
+      tar xzf ${_src} -C ${_dest} && rm -rf ${_src}
+      return $?
+      ;;
+    "tar" )
+      tar xf ${_src} -C ${_dest} && rm -rf ${_src}
+      return $?
+      ;;
+    * )
+      echo "Unsupported archive type"
+      return 1
+  esac
+}
+
+# Two params
+# $1: Path to metadata directory
+# $2: Transformer
+function ingestData() {
+  _ingest_directory=${1}
+  _xformer=${2}
+  if [ -n "${_xformer}" ]; then
+    echo -e "Ingesting data:\n\tFrom:\t${_ingest_directory}\n\tType:\t${_xformer}"
+    ${_client} "catalog:ingest -t ${_xformer} ${_ingest_directory}"
+    return $?
+  else
+    echo -e "Ingesting data:\n\tFrom:\t${_ingest_directory}"
+    ${_client} "catalog:ingest ${_ingest_directory}"
+    return $?
+  fi
+}
+
+function main() {
+  _staging_directory="/tmp/ingest"
+
+  IFS=',' read -r -a _ingest_data <<< "${INGEST_DATA}"
+
+  for index in "${!_ingest_data[@]}"
+  do
+    IFS='|' read -r -a _current_data <<< "${_ingest_data[$index]}"
+    _data_location=${_current_data[0]}
+    _data_filename=$(basename ${_data_location})
+    _data_format=${_data_filename#*.}
+    _data_transformer=${_current_data[1]}
+    _staging_archive_path="${_staging_directory}/${_data_filename%%.*}/${_data_filename}"
+    _staging_path=$(dirname $_staging_archive_path)
+
+    echo -e "Current Data:\n\tLocation:\t${_data_location}\n\tFilename:\t${_data_filename}\n\tFormat: \t${_data_format}\n\tTransformer:\t${_data_transformer}"
+    case "${_data_location}" in
+      http*://* )
+        retrieveRemoteData ${_data_location} ${_staging_archive_path} \
+        && unpackData ${_staging_archive_path} ${_staging_path} ${_data_format} \
+        && ingestData ${_staging_path} ${_data_transformer}
+        return $?
+        ;;
+      file://* )
+        copyLocalData ${_data_location} ${_staging_archive_path} \
+        && unpackData ${_staging_archive_path} ${_staging_path} ${_data_format} \
+        && ingestData ${_staging_path} ${_data_transformer}
+        return $?
+        ;;
+      * )
+        echo -e "Unsupported file location, must be one of\n\thttps://\n\thttp://\n\tfile://"
+        return 1
+    esac
+  done
+}
+
+main
+exit $?

--- a/2.12/linux/entrypoint/post_start.sh
+++ b/2.12/linux/entrypoint/post_start.sh
@@ -42,6 +42,10 @@ if [ -n "$LDAP_HOST" ]; then
   cp $ENTRYPOINT_HOME/config/ldap/*.config ${_app_etc}
 fi
 
+if [ -n "$INGEST_DATA" ]; then
+  $ENTRYPOINT_HOME/ingest_data.sh
+fi
+
 if [ -d "$ENTRYPOINT_HOME/post" ]; then
   for f in "$ENTRYPOINT_HOME/post/*";
     do

--- a/README.md
+++ b/README.md
@@ -112,6 +112,26 @@ Only applicable when using `CA_REMOTE_URL`
 | `CSR_STATE`               | Sets the State value for the generated Certificate               | `AZ`                           |
 | `CSR_PROFILE`             | Sets the type of certificate requested from the CA               | `server`                       |
 
+### Seeding Catalog Data
+
+To ingest data automatically after the system is running, the `INGEST_DATA` environment variable can be used.
+It can take a comma separated list of locations to retrieve archives of metadata from: `https://foo.bar/baz.zip,http://fake.com/foo.tar.gz`
+Supported archive types are:
+- `zip`
+- `tar`
+- `tar.gz`
+- `tgz`
+
+Supported protocols are:
+- `http://`
+- `https://`
+- `file://`
+
+Optionally a transformer for each set of data can be specified by adding `|<transformerName>` after each item in the list
+
+Full Example:
+`INGEST_DATA=https://foo.bar/baz.zip|xml,http://fake.com/foo.tar.gz|geojson,file:///some/local/file.zip`
+
 ### Troubleshooting
 
 Sometimes during the startup process the system can take a while to fully initialize. This can be due to memory/cpu constraints. On underpowered systems it might be necessary to instruct the entrypoint script to wait longer and attempt more retries to connect to the system during the boot process. This can be accomplished by setting the `KARAF_CLIENT_DELAY=<time> (default: 10)` (in seconds) or `KARAF_CLIENT_RETRIES=<number> (default: 12)`


### PR DESCRIPTION
Resolves #39 

* Adds support for seeding catalog data
  * Supports zip, tar, tar.gz archive formats
  * Supports an arbitrary number of archives
  * Supports local and remote archives

## To Do:
- [x] Update Documentation
- [x] Add support for listings that without a defined transformer
- [x] Gracefully handle failures
