### PR TITLE
Update the JAVA_MAX_MEM without wiping out other JAVA_OPS

### DIFF
--- a/2.11/linux/entrypoint/pre_start.sh
+++ b/2.11/linux/entrypoint/pre_start.sh
@@ -45,7 +45,7 @@ if [ -n "$HTTPS_PORT" ]; then
 fi
 
 if [ -n "$JAVA_MAX_MEM" ]; then
-   sed -i "s/Xmx.* /Xmx${JAVA_MAX_MEM}g /g" $APP_HOME/bin/setenv
+   sed -i "s/Xmx.*g /Xmx${JAVA_MAX_MEM}g /g" $APP_HOME/bin/setenv
 fi
 
 # Copy any existing configuration files before starting the container

--- a/2.12/linux/entrypoint/pre_start.sh
+++ b/2.12/linux/entrypoint/pre_start.sh
@@ -60,7 +60,7 @@ if [ -n "$BASE_URL_HTTPS_PORT" ]; then
 fi
 
 if [ -n "$JAVA_MAX_MEM" ]; then
-   sed -i "s/Xmx.* /Xmx${JAVA_MAX_MEM}g /g" ${_setenv_file}
+   sed -i "s/Xmx.*g /Xmx${JAVA_MAX_MEM}g /g" ${_setenv_file}
 fi
 
 if [ "${SECURITY_MANAGER_DISABLED}" = true ]; then


### PR DESCRIPTION
Noticed that previous command will clean out all the Java options after the Xmx setting.  This should just replace the Xmx number only.  