### PR TITLE
Improved Readiness Checks

### DIFF
--- a/2.12/linux/entrypoint/post_start.sh
+++ b/2.12/linux/entrypoint/post_start.sh
@@ -10,16 +10,11 @@ do
 done
 echo -e "\nLog file found, continuing..."
 
-_wfrStatus=1
-while [ ${_wfrStatus} -ne 0 ]
-do
-  echo "Checking if ${APP_NAME} is ready..."
-  ${_client} "while { (bundle:list -t 0 | grep -i \"active.*DDF\s::\sadmin\s::\sUI\" | tac) isEmpty } { echo -n \". \"; sleep 1 }; while {(\"3\" equals ((bundle:list -t 0 | grep -i -v \"active\" | grep -i \"hosts:\" | wc -l | tac) trim) | tac) equals \"false\"} { echo -n \". \"; sleep 1 }; echo \"\"; echo \"System Ready\""
-  _wfrStatus=$?
-done
+waitForReady
 
 if [ -n "$INSTALL_PROFILE" ]; then
   ${_client} profile:install ${INSTALL_PROFILE}
+  waitForReady
 fi
 
 if [ -n "$INSTALL_FEATURES" ]; then

--- a/README.md
+++ b/README.md
@@ -30,6 +30,24 @@ Pre-start steps are all performed prior to the ddf instance being started, while
 
 Both of these sets of steps can be extended easily using the following methods.
 
+### Customizing Readiness Check
+
+There are a few protections in place in this image to help get timings right when performing installations. The default approach checks if all bundles are started before considering the system "ready"
+By default there are a few bundles that are excluded from this check. These defaults can be overriden via the `READINESS_EXCLUSIONS` environment variable
+
+The default exclusions are: `Apache Karaf :: Features :: Extension, Hosts|DDF :: Platform :: OSGi :: Conditions, Hosts|Apache Karaf :: Shell :: Console, Hosts|DDF :: Platform :: PaxWeb :: Jetty Config, Hosts`
+Exclusions must be a string that is separated by `|` characters for each entry
+Downstream images that need a custom set of exclusions should override via their `Dockerfile`:
+
+```Dockerfile
+...
+ENV READINESS_EXCLUSIONS="some bundle name|another bundle name|yet another bundle name"
+...
+```
+
+Additionally for distributions that make use of the fabric8 health/readiness endpoint the experimental health checks can be used instead of the older approach by setting `EXPERIMENTAL_READINESS_CHECKS_ENABLED=true`
+*Note:* This requires that the `fabric8-karaf-checks` feature is installed as part of the distribution's boot features
+
 ### Pre-Start Extensions
 
 For simple extension, add a script: `$ENTRYPOINT_HOME/pre_start_custom.sh`


### PR DESCRIPTION
Adds better methods for determining system readiness

The use of `waitForReady` was proving very brittle. often it would either exit too early or just exit immediately if the client ran into a problem. This replaces the usage of waitForReady with some shell functions.

By default, the new `isReady` function will use a similar method to the old `waitForReady` command. This new method gets the output of `lna` and filters out the table header, next it filters out any bundles included in the `READINESS_EXCLUSIONS` variable, finally it counts the number of bundles left in the list. If the number of bundles is not `0` it returns an exit code of `1`. If the number of bundles in the list is equal to `0` it returns an exit code of `0`

This `isReady` function is used by the new `waitForReady` function which will just block further execution until `isReady` returns `0`

Further, the behavior of the `isReady` function can be altered by setting `EXPERIMENTAL_READINESS_CHECKS_ENABLED=true`. When this variable is present the `isReady` function will utilize the `fabric8-karaf-checks` provided endpoint to determine the readiness of the system instead of the `lna` based approach