### PR TITLE
Automatically disable local solr when remote solr instance is provided

### DIFF
--- a/2.12/linux/entrypoint/global_env.sh
+++ b/2.12/linux/entrypoint/global_env.sh
@@ -37,6 +37,7 @@ _solr_client_key="solr.client"
 _solr_http_url_key="solr.http.url"
 _solr_cloud_url_key="solr.cloud.zookeeper"
 _solr_data_key="solr.data.dir"
+_solr_start_key="start.solr"
 # Ldap
 _ldap_hostname_key="org.codice.ddf.ldap.hostname"
 _ldap_port_key="org.codice.ddf.ldap.port"

--- a/2.12/linux/entrypoint/pre_start.sh
+++ b/2.12/linux/entrypoint/pre_start.sh
@@ -17,11 +17,13 @@ if [ -n "$SOLR_ZK_HOSTS" ]; then
   props del ${_solr_http_url_key} ${_system_properties_file}
   props set ${_solr_cloud_url_key} $SOLR_ZK_HOSTS ${_system_properties_file}
   props del ${_solr_data_key} ${_system_properties_file}
+  props set ${_solr_start_key} false ${_system_properties_file}
 fi
 
 if [ -n "$SOLR_URL" ]; then
   echo "Remote Solr Support is enabled, solr url: $SOLR_URL"
   props set ${_solr_http_url_key} ${SOLR_URL} ${_system_properties_file}
+  props set ${_solr_start_key} false ${_system_properties_file}
 fi
 
 # TODO: add more fine grained ldap configuration support


### PR DESCRIPTION
If either `SOLR_URL` or `SOLR_ZK_HOSTS` are provided the internal solr instance will be disabled