### PR TITLE
Fix hostname and port settings, update variable names

### DIFF
--- a/2.14/linux/entrypoint/certs_env.sh
+++ b/2.14/linux/entrypoint/certs_env.sh
@@ -6,8 +6,8 @@ _remote_ca=${CA_REMOTE_URL:=""} # Set to host:port for remote CFSSL based CA
 _storepass=changeit
 _trustStoreOpts="-keystore ${_server_truststore_file} -storepass ${_storepass} -noprompt"
 _keytoolOpts="-keystore ${_server_keystore_file} -storepass ${_storepass} -noprompt"
-_san=DNS:${_app_hostname},DNS:localhost,IP:127.0.0.1
-_keyAlias=${_app_hostname}
+_san=DNS:${_system_internal_hostname},DNS:${_system_external_hostname},DNS:localhost,IP:127.0.0.1
+_keyAlias=${_system_external_hostname}
 
 DUMMY_DELETE_OPTS="-delete -alias localhost ${_keytoolOpts}"
 

--- a/2.14/linux/entrypoint/global_env.sh
+++ b/2.14/linux/entrypoint/global_env.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 
-# Determine the hostname used for the system, if not overridden by APP_HOSTNAME, defaults to the value of `hostname -f`
+# Determine the internal hostname used for the system, if not overridden by APP_HOSTNAME, defaults to the value of `hostname -f`
 _app_hostname=${APP_HOSTNAME:=$(hostname -f)}
-_system_user_privileges="${_app_hostname},group,admin,manager,viewer,system-admin,system-history,systembundles"
+_system_internal_hostname=${INTERNAL_HOSTNAME:=${_app_hostname}}
+_system_external_hostname=${EXTERNAL_HOSTNAME:=${_system_internal_hostname}}
+_system_user_privileges="${_system_internal_hostname},group,admin,manager,viewer,system-admin,system-history,systembundles"
 
 _ldap_port=${LDAP_PORT:=1636}
 
@@ -28,14 +30,18 @@ _system_hostname_key="org.codice.ddf.system.hostname"
 _system_sitename_key="org.codice.ddf.system.siteName"
 _system_https_port_key="org.codice.ddf.system.httpsPort"
 _system_http_port_key="org.codice.ddf.system.httpPort"
-_system_internal_http_port="org.codice.ddf.system.internalHttpPort"
-_system_internal_https_port="org.codice.ddf.system.internalHttpsPort"
 _default_http_port=8181
 _default_https_port=8993
 _system_external_protocol_key="org.codice.ddf.external.protocol"
 _system_external_hostname_key="org.codice.ddf.external.hostname"
 _system_external_https_port_key="org.codice.ddf.external.httpsPort"
 _system_external_http_port_key="org.codice.ddf.external.httpPort"
+
+_system_internal_https_port=${INTERNAL_HTTPS_PORT:=${_default_https_port}}
+_system_internal_http_port=${INTERNAL_HTTP_PORT:=${_default_http_port}}
+_system_external_https_port=${EXTERNAL_HTTPS_PORT:=${_default_https_port}}
+_system_external_http_port=${EXTERNAL_HTTP_PORT:=${_default_http_port}}
+
 # Solr
 _solr_client_key="solr.client"
 _solr_http_url_key="solr.http.url"

--- a/2.14/linux/entrypoint/load_certs.sh
+++ b/2.14/linux/entrypoint/load_certs.sh
@@ -120,7 +120,7 @@ function main {
   echo "Preparing to import provided cert from 'SSL_CERT'"
   checkIfAlreadyDone
   if [ $? -eq 0 ]; then
-    echo "Certificate for ${_app_hostname} already present in ${_server_keystore_file}, skipping import of certs"
+    echo "Certificate for ${_system_internal_hostname} already present in ${_server_keystore_file}, skipping import of certs"
     return 0
   fi
 

--- a/2.14/linux/entrypoint/local_ca_request.sh
+++ b/2.14/linux/entrypoint/local_ca_request.sh
@@ -37,9 +37,9 @@ openssl ca \
         -in ${_app_local_ca}/${_keyAlias}.csr \
         -out ${_app_local_ca}/newcerts/${_keyAlias}.cer > /dev/null 2>&1
 
-cat ${_app_local_ca}/cacert.pem \
+cat ${_app_local_ca}/private/${_keyAlias}.key \
     ${_app_local_ca}/newcerts/${_keyAlias}.cer \
-    ${_app_local_ca}/private/${_keyAlias}.key \
+    ${_app_local_ca}/cacert.pem \
     > ${_app_local_ca}/private/${_keyAlias}.pem
 
 openssl pkcs12 \

--- a/2.14/linux/entrypoint/local_ca_request.sh
+++ b/2.14/linux/entrypoint/local_ca_request.sh
@@ -2,10 +2,10 @@
 
 source ${ENTRYPOINT_HOME}/certs_env.sh
 
-_subject="/C=US/ST=AZ/L=Hursley/O=DDF/OU=Dev/CN=${_app_hostname}"
+_subject="/C=US/ST=AZ/L=Hursley/O=DDF/OU=Dev/CN=${_system_external_hostname}"
 _serial=$(cat /dev/urandom | tr -dc '0-9' | fold -w 16 | head -n 1)
 
-echo "External Hostname: ${_app_hostname}"
+echo "External Hostname: ${_system_external_hostname}"
 echo "Alternative Names: ${_san}"
 echo "Updating ${APP_NAME} certificates"
 

--- a/2.14/linux/entrypoint/remote_ca_request.sh
+++ b/2.14/linux/entrypoint/remote_ca_request.sh
@@ -66,9 +66,9 @@ cat ${_tmp_cert_dir}/ca-response.json | jq .result.certificate --raw-output > ${
 cat ${_tmp_cert_dir}/ca-response.json | jq .result.private_key --raw-output > ${_tmp_cert_dir}/$_keyAlias.key
 openssl s_client -connect ${_remote_ca#https://} -showcerts </dev/null 2>/dev/null|openssl x509 -outform PEM > ${_tmp_cert_dir}/ca.pem
 
-cat ${_tmp_cert_dir}/ca.pem \
+cat ${_tmp_cert_dir}/${_keyAlias}.key \
     ${_tmp_cert_dir}/${_keyAlias}.pem \
-    ${_tmp_cert_dir}/${_keyAlias}.key \
+    ${_tmp_cert_dir}/ca.pem \
     > ${_tmp_output_dir}/${_keyAlias}.pem
 
 openssl pkcs12 \

--- a/2.14/linux/entrypoint/remote_ca_request.sh
+++ b/2.14/linux/entrypoint/remote_ca_request.sh
@@ -15,7 +15,7 @@ function join_by { local d=$1; shift; echo -n "$1"; shift; printf "%s" "${@/#/$d
 _remote_request_key_alg=${CSR_KEY_ALGORITHM:="rsa"}
 _remote_request_key_size=${CSR_KEY_SIZE:="2048"}
 _remote_request_hosts=${_san}
-_remote_request_cn=${_app_hostname}
+_remote_request_cn=${_system_external_hostname}
 _remote_request_names_country=${CSR_COUNTRY:="US"}
 _remote_request_names_locality=${CSR_LOCALITY:="Hursley"}
 _remote_request_names_organization=${CSR_ORGANIZATION:="DDF"}

--- a/README.md
+++ b/README.md
@@ -22,6 +22,15 @@ ENV APP_LOG=<log_file>
 ...
 # Install application
 ```
+## Features
+  * Oracle JDK8
+  * [jq](https://stedolan.github.io/jq/) for processing json
+  * curl
+  * [props](https://github.com/oconnormi/props) tool for modifying properties files
+  * Common entry point for DDF based distributions
+  * Automated certificate generation
+  * Automated initial setup and configuration
+    * Can request certs from a remote cfssl based CA via `CA_REMOTE_URL=https://<host>:<port>`  
 
 ## Extending
 
@@ -58,25 +67,40 @@ For more complex extension, any number of executable files can be added to `$ENT
 For simple extension, add a script: `$ENTRYPOINT_HOME/post_start_custom.sh`
 For more complex extension, any number of executable files can be added to `$ENTRYPOINT_HOME/post/`
 
-## Features
-  * Oracle JDK8
-  * [jq](https://stedolan.github.io/jq/) for processing json
-  * curl
-  * [props](https://github.com/oconnormi/props) tool for modifying properties files
-  * Common entry point for DDF based distributions
-  * Automated certificate generation
-  * Automated initial setup and configuration
-    * Can request certs from a remote cfssl based CA via `CA_REMOTE_URL=https://<host>:<port>`  
-
 ### Basic Configuration
 
-To set the hostname used by DDF based systems, provide a value to `APP_HOSTNAME=<hostname>`
+#### System Hostname
+
+To set the external hostname used by DDF based systems, provide a value to `EXTERNAL_HOSTNAME=<hostname>`. This will be the hostname that all external requests to the system should use.
+
+To set the internal hostname used by DDF based systems, provide a value to `INTERNAL_HOSTNAME=<hostname>`
+
+#### Internal System Ports
+
+*Note:* Setting these options changes the ports that are actually bound by the server. In most cases this should not be necessary.
+
+To set the internal HTTPS Port provide a value for `INTERNAL_HTTPS_PORT=<port>`
+
+To set the internal HTTP Port provide a value for `INTERNAL_HTTP_PORT=<port>`
+
+#### External System Ports
+
+*Note:* Setting these options affect the url that the server expects external requests to use.
+
+To set the external HTTPS Port provide a value for `EXTERNAL_HTTPS_PORT=<port>`
+
+To set the external HTTP Port provide a value for `EXTERNAL_HTTP_PORT=<port>`
+
+#### External Solr
 
 To configure a solr backend, provide a value to `SOLR_URL=<external solr url>`. By default this will use the internal solr server
 
 To configure a solr cloud backend, provide a value to `SOLR_ZK_HOSTS=<zk host>,<zk host>,<zk host>,...`
+#### External LDAP
 
 To configure the ldap client, provide a value to `LDAP_HOST=<hostname>`. *NOTE:* Currently this is for testing purposes only, as it does not provide a means for configuring the protocol, port, username, or password used by the ldap client.
+
+#### Java Memory
 
 To set the amount of memory allocated to the system set `JAVA_MAX_MEM`
 
@@ -105,9 +129,9 @@ Custom keystores can easily be mounted to `APP_HOME/etc/keystores/serverKeystore
 
 #### Auto-generated demo certs
 
-If custom keystores are not used the startup process will generate certificates on the fly. By default the local ddf demo CA (bundled within the ddf distribution) will be used to generate a certificate for the value of `APP_HOSTNAME`, or if not provided the value of `hostname -f` will be used.
+If custom keystores are not used the startup process will generate certificates on the fly. By default the local ddf demo CA (bundled within the ddf distribution) will be used to generate a certificate for the value of `INTERNAL_HOSTNAME`, or if not provided the value of `hostname -f` will be used.
 
-Additionally Subject Alternative Names will be added to the certificate for `DNS:$APP_HOSTNAME(if unset will use `hostname -f`),DNS:localhost,IP:127.0.0.1`.
+Additionally Subject Alternative Names will be added to the certificate for `DNS:$INTERNAL_HOSTNAME(if unset will use `hostname -f`),$EXTERNAL_HOSTNAME,DNS:localhost,IP:127.0.0.1`.
 To add additional SAN values use the `CSR_SAN=<DNS|IP>:<value>,...` environment variable.
 
 #### Import Existing Certificates
@@ -211,3 +235,4 @@ Sometimes during the startup process the system can take a while to fully initia
 
 ## Deprecated features
 * `APP_NODENAME=<node_name>` *DEPRECATED* use `CSR_SAN=<DNS|IP>:<value>,...` instead
+* `APP_HOSTNAME=<hostname>` *DEPRECATED* use `INTERNAL_HOSTNAME=<hostname>` instead


### PR DESCRIPTION
# Description
There were some minor issues with how internal and external hostnames and ports were being set that caused the system to not work correctly behind certain proxy configurations. As part of this fix variable names have been updated to make things more consistent. The old variables have been preserved for backwards compatibility, but will print a warning to the console when used advising that the new option be used in the future.

## Fixes
* Removes old and unnecessary property usage for setting the internal hostname
* Adds both internal and external hostnames to the SAN when generating a CSR

## Deprecated Variables

Any deprecated variables have been replaced with new variables with the intent of making it more clear what they are used for. It should now be easier to understand how each of these new variables will actually affect the system.

|Deprecated Variable|New Variable|
|-------------------|------------|
|HTTPS_PORT|INTERNAL_HTTPS_PORT|
|HTTP_PORT|INTERNAL_HTTP_PORT|
|BASE_URL_HTTP_PORT|EXTERNAL_HTTP_PORT|
|BASE_URL_HTTPS_PORT|EXTERNAL_HTTPS_PORT|
|EXTERNAL_URL|EXTERNAL_HOSTNAME|
|APP_HOSTNAME|INTERNAL_HOSTNAME|

## Todo
- [x] Fix certificate chain order
- [x] Update README