### PR TITLE
Add support for changing the service context paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,18 @@ To set the external HTTPS Port provide a value for `EXTERNAL_HTTPS_PORT=<port>`
 
 To set the external HTTP Port provide a value for `EXTERNAL_HTTP_PORT=<port>`
 
+#### Internal Service Context
+
+Change the root context for all services
+
+Set `INTERNAL_CONTEXT=<context_path>`
+
+#### External Service Context
+
+Change the context for services when running behind a proxy/load balancer
+
+Set `EXTERNAL_CONTEXT=<context_path>`
+
 #### Site Name
 
 To set the site name for the system provide a value to `SITE_NAME=<name>`. This defaults to the external hostname of the system when omitted.

--- a/entrypoint/global_env.sh
+++ b/entrypoint/global_env.sh
@@ -45,6 +45,14 @@ _system_internal_https_port=${INTERNAL_HTTPS_PORT:=${_default_https_port}}
 _system_internal_http_port=${INTERNAL_HTTP_PORT:=${_default_http_port}}
 _system_external_https_port=${EXTERNAL_HTTPS_PORT:=${_default_https_port}}
 _system_external_http_port=${EXTERNAL_HTTP_PORT:=${_default_http_port}}
+
+_default_system_context="/services"
+_system_external_context_key="org.codice.ddf.external.context"
+_system_internal_context_key="org.codice.ddf.system.rootContext"
+_system_internal_context=${INTERNAL_CONTEXT:=${_default_system_context}}
+_default_external_context=${EXTERNAL_CONTEXT:=${_system_internal_context}}
+_system_external_context=${EXTERNAL_CONTEXT:=${_default_external_context}}
+
 _system_sitename=${SITE_NAME:=${_system_external_hostname}}
 
 # Solr

--- a/entrypoint/global_env.sh
+++ b/entrypoint/global_env.sh
@@ -47,10 +47,10 @@ _system_external_https_port=${EXTERNAL_HTTPS_PORT:=${_default_https_port}}
 _system_external_http_port=${EXTERNAL_HTTP_PORT:=${_default_http_port}}
 
 _default_system_context="/services"
+_default_external_context=""
 _system_external_context_key="org.codice.ddf.external.context"
 _system_internal_context_key="org.codice.ddf.system.rootContext"
 _system_internal_context=${INTERNAL_CONTEXT:=${_default_system_context}}
-_default_external_context=${EXTERNAL_CONTEXT:=${_system_internal_context}}
 _system_external_context=${EXTERNAL_CONTEXT:=${_default_external_context}}
 
 _system_sitename=${SITE_NAME:=${_system_external_hostname}}

--- a/entrypoint/pre_start.sh
+++ b/entrypoint/pre_start.sh
@@ -12,6 +12,8 @@ props set ${_system_external_http_port_key} ${_system_external_http_port} ${_sys
 props set ${_system_https_port_key} ${_system_internal_https_port} ${_system_properties_file}
 props set ${_system_http_port_key} ${_system_internal_http_port} ${_system_properties_file}
 props set ${_system_hostname_key} ${_system_internal_hostname} ${_system_properties_file}
+props set ${_system_internal_context_key} ${_system_internal_context} ${_system_properties_file}
+props set ${_system_external_context_key} ${_system_external_context} ${_system_properties_file}
 
 if props get localhost ${_users_properties_file} > /dev/null ; then
   props del localhost ${_users_properties_file}


### PR DESCRIPTION
Adds support for changing the context paths for services

* `INTERNAL_CONTEXT` sets actual context path
* `EXTERNAL_CONTEXT` sets context path for use with proxy/load balancer